### PR TITLE
Link to publicly available slides on Google Drive

### DIFF
--- a/presentations/slides_on_google_drive.txt
+++ b/presentations/slides_on_google_drive.txt
@@ -1,0 +1,3 @@
+Public link for slides on Google Drive (earthmicrobiomeproject500@gmail.com):
+https://drive.google.com/folderview?id=0B5Jf0YWOCWp6eEZ5MmFYRUtvYUE&usp=sharing
+


### PR DESCRIPTION
Many of the EMP presentations are huge. Storing them on Google Drive reduces the disk load on GitHub.