### PR TITLE
filter files for sub-sets

### DIFF
--- a/ipynb/filterEMP.ipynb
+++ b/ipynb/filterEMP.ipynb
@@ -1,0 +1,274 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Author**: stefan.m.janssen@gmail.com<br>\n",
+    "**Date**: 08 Aug 2016<br>\n",
+    "**language**: Python 3.5.2 :: Continuum Analytics, Inc.<br>\n",
+    "**conda enviroment**: micronota<br>\n",
+    "**license**: unlicensed<br>\n",
+    "\n",
+    "# Filter EMP\n",
+    "Currently the EMP comprises ~34k samples. Sometimes we need to operate on smaller sample numbers. Thus, the merged mapping file contains 'subset_xxx' columns, where xxx indicates the number of samples in the subset. These columns are np.boolean and flags if a sample of the whole EMP is part of subset xxx.\n",
+    "\n",
+    "There are several point where we need to filter full data-sets to those smaller subsets, e.g. BIOM tables or beta diversity distance matrices. This notebook is an example of how to acomplish that. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# a trick to make it transparent if executed on a barnacle node or on my machine with barnacles file system mounted to /media/barnacle\n",
+    "import socket\n",
+    "ROOT = \"/media/barnacle/\" if socket.gethostname() == 't440s' else \"/\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "\n",
+    "# make all necessary imports\n",
+    "import pandas as pd\n",
+    "import sys\n",
+    "import os\n",
+    "import biom\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "the next cell contains all parameters that might need to be changed"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# file_mapping points to the merged EMP mapping file, which contains columns like 'subset_2000'.\n",
+    "file_mapping = ROOT + '/projects/emp/00-qiime-maps/merged/emp_qiime_mapping_latest.tsv'\n",
+    "\n",
+    "# BIOM Tables:\n",
+    "# file_biom points to the full BIOM table, i.e. the input file\n",
+    "file_biom = ROOT + '/projects/emp/03-otus/01-closed-ref-greengenes/emp_cr_gg_13_8.biom'\n",
+    "# filename of the resulting filtered BIOM table, i.e. the output file\n",
+    "file_biom_subset = \"./filtered.biom\"\n",
+    "\n",
+    "# Beta Diversity Matrices:\n",
+    "# filename of the full beta diversity matrix, i.e. the input file\n",
+    "file_betaDiv = ROOT + '/projects/emp/06-beta/01-closed-ref-greengenes/emp_cr_gg_13_8.bdiv-unweighted-unifrac.result'\n",
+    "# filename of the resulting filtered beta diversity matrix, i.e. the output file\n",
+    "file_betaDiv_subset = \"./filtered_betadiv.txt\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Reads a biom table from 'sourceFile' and remains only those samples whose IDs are in the list 'sampleIDsToKeep'. Result will be written to the file 'targetFile'\n",
+    "\n",
+    "def filterBiomTable(sampleIDsToKeep, sourceFile, targetFile):\n",
+    "    targetFile = os.path.abspath(targetFile)\n",
+    "    \n",
+    "    print(\"Loading source biom table ...\", end=\"\")\n",
+    "    counts = biom.load_table(sourceFile)\n",
+    "    \n",
+    "    #collect available sample IDs from input biom table (some IDs of the list 'sampleIDsToKeep' might not be in the input biom file, e.g. if we don't have sequence reads)\n",
+    "    counts_idx = counts.ids('sample')\n",
+    "    print(\" which holds \" + str(len(counts_idx)) + \" samples.\")\n",
+    "\n",
+    "    toBeFiltered_idx = list(set(counts_idx) & set(sampleIDsToKeep))\n",
+    "    notFound = list(set(sampleIDsToKeep) - set(counts_idx))\n",
+    "    print(\"Sub-sampling down to \" + str(len(toBeFiltered_idx)) + \" of which \" + str(len(notFound)) + \" are not in the input BIOM table.\")\n",
+    "    \n",
+    "    #actual filtering\n",
+    "    counts_subset = counts.filter(toBeFiltered_idx, axis='sample', inplace=False)\n",
+    "    \n",
+    "    #create the new filename\n",
+    "    print(\"Writing resulting biom table to '\"+ targetFile +\"'\")\n",
+    "    with biom.util.biom_open(targetFile, 'w') as f:\n",
+    "        counts_subset.to_hdf5(f, \"EMP sub-set generation notebook\")\n",
+    "        \n",
+    "    print(\"Generating summary.\")\n",
+    "    inp = targetFile\n",
+    "    out = targetFile + \".summary.txt\"\n",
+    "    !biom summarize-table -i \"$inp\" > \"$out\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Reads a (beta diversity) distance matrix from 'sourceFile' and returns only those cells that belong to samples that are listed in 'sampleIDsToKeep'. Output is written to 'targetFile'\n",
+    "\n",
+    "def filterBetadivMatrix(sampleIDsToKeep, sourceFile, targetFile):\n",
+    "    targetFile = os.path.abspath(targetFile)\n",
+    "    out = open(targetFile, \"w\")\n",
+    "    f = open(sourceFile, \"r\")\n",
+    "    columnsToKeep = []\n",
+    "    foundIdx = []\n",
+    "    lidx = list(sampleIDsToKeep)\n",
+    "    matrixIdx = f.readline().rstrip().split(\"\\t\")\n",
+    "    for i, sid in enumerate(matrixIdx):\n",
+    "        if sid in lidx:\n",
+    "            columnsToKeep.append(i)\n",
+    "            foundIdx.append(sid)\n",
+    "            out.write(\"\\t\" + sid)\n",
+    "    out.write(\"\\n\")\n",
+    "    \n",
+    "    notFound = list(set(sampleIDsToKeep) - set(foundIdx))\n",
+    "    print(\"Sub-sampling down to \" + str(len(sampleIDsToKeep)) + \" of which \" + str(len(notFound)) + \" are not in the input matrix.\")\n",
+    "    \n",
+    "    for lineCount, line in enumerate(f):\n",
+    "        fields = line.rstrip().split(\"\\t\")\n",
+    "        if fields[0] in lidx:\n",
+    "            out.write(fields[0])\n",
+    "            for i in columnsToKeep:\n",
+    "                out.write(\"\\t\" + fields[i])\n",
+    "            out.write(\"\\n\")\n",
+    "        if (lineCount % int(len(matrixIdx) / 10) == 0):\n",
+    "            print(\"  processed \" + str(int(lineCount / len(matrixIdx) * 100)) + \" %\")\n",
+    "            \n",
+    "    print(\"wrote resulting distance matrix to '\" +targetFile+ \"'\")\n",
+    "    out.close()\n",
+    "    f.close()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "#we load the mapping file into a Pandas dataframe\n",
+    "metadata = pd.read_csv(file_mapping, sep=\"\\t\", index_col=0, low_memory=False)\n",
+    "\n",
+    "#we chose a (sub-)set of sample IDs which we want to have in our output set. E.g. all sampleIDs that have a np.True_ in the 'subset_2000' column, i.e. those 2000 samples that form the EMP 2000 sub-set \n",
+    "idx = metadata[metadata['subset_2000'] == np.True_].index\n",
+    "\n",
+    "#another example: choose all samples that are annotated as 'Animal distal gut' in EMPO level 3\n",
+    "#idx = metadata[metadata.empo_3 == 'Animal distal gut'].index"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loading source biom table ... which holds 27398 samples.\n",
+      "Sub-sampling down to 1999 of which 1 are not in the input BIOM table.\n",
+      "Writing resulting biom table to './filtered.biom'\n",
+      "Generating summary.\n"
+     ]
+    }
+   ],
+   "source": [
+    "filterBiomTable(idx, file_biom, file_biom_subset)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "It is also useful to filter in the same way the beta diversity metrices, which are of huge file size for the full EMP data-set (~14GB)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Sub-sampling down to 2000 of which 1 are not in the input matrix.\n",
+      "  processed 0 %\n",
+      "  processed 9 %\n",
+      "  processed 19 %\n",
+      "  processed 29 %\n",
+      "  processed 39 %\n",
+      "  processed 49 %\n",
+      "  processed 59 %\n",
+      "  processed 69 %\n",
+      "  processed 79 %\n",
+      "  processed 89 %\n",
+      "  processed 99 %\n",
+      "wrote resulting distance matrix to '/home/sjanssen/EMP/filtered_betadiv.txt'\n",
+      "CPU times: user 49.1 s, sys: 5.69 s, total: 54.8 s\n",
+      "Wall time: 55.3 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%time filterBetadivMatrix(idx, file_betaDiv, file_betaDiv_subset)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "celltoolbar": "Raw Cell Format",
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
Added a notebook to filter full BIOM tables and/or beta dioversity distance matrices down to a set of given sampleIDs, e.g. those that form the 2k sub-set.